### PR TITLE
Update README.md with an extra prometheus.yml config option that prevents an error that stops the container from starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Finally, add a new job to `prometheus.yml`.
 scrape_configs:
   # ...
   - job_name: 'docker'
+    fallback_scrape_protocol: PrometheusText0.0.4
     static_configs:
     - targets: ['your-docker-host:9417']
 ```


### PR DESCRIPTION
When starting the prometheus container the following error is shown and the container fails to start:

'Error scraping target: non-compliant scrape target sending blank Content-Type and no fallback_scrape_protocol specified for target'

Adding in the config option 'fallback_scrape_protocol: PrometheusText0.0.4' in the scrape configs job section allows the container to start up.